### PR TITLE
Fix Image imports on Fedora 19

### DIFF
--- a/src/burnet/mockmodel.py
+++ b/src/burnet/mockmodel.py
@@ -21,11 +21,15 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 import random
-import Image
-import ImageDraw
-
 import platform
 import subprocess
+
+try:
+    from PIL import Image
+    from PIL import ImageDraw
+except ImportError:
+    import Image
+    import ImageDraw
 
 import burnet.model
 import burnet.vmtemplate

--- a/src/burnet/screenshot.py
+++ b/src/burnet/screenshot.py
@@ -23,10 +23,14 @@
 
 import os
 import time
-import Image
 import random
 import uuid
 import glob
+
+try:
+    from PIL import Image
+except ImportError:
+    import Image
 
 import config
 


### PR DESCRIPTION
More info here: http://lists.debian.org/debian-python/2013/02/msg00017.html

Though Fedora doesn't seem to provide those back compat imports.
