### PR TITLE
Rename README to README.md

### DIFF
--- a/README
+++ b/README
@@ -1,1 +1,0 @@
-docs/README.md

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+docs/README.md


### PR DESCRIPTION
This fixes the fact that github displays the `README` as plain text instead of markdown.
