### PR TITLE
Bug Fix: automake file config for xmlutils

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -83,6 +83,7 @@ AC_CONFIG_FILES([
     src/kimchi/Makefile
     src/kimchi/control/Makefile
     src/kimchi/control/vm/Makefile
+    src/kimchi/xmlutils/Makefile
     src/kimchi/model/Makefile
     plugins/Makefile
     plugins/sample/Makefile

--- a/src/kimchi/Makefile.am
+++ b/src/kimchi/Makefile.am
@@ -17,7 +17,7 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-SUBDIRS = control model
+SUBDIRS = control model xmlutils
 
 kimchi_PYTHON = $(filter-out config.py, $(wildcard *.py))
 

--- a/src/kimchi/xmlutils/Makefile.am
+++ b/src/kimchi/xmlutils/Makefile.am
@@ -1,0 +1,25 @@
+#
+# Kimchi
+#
+# Copyright Intel Corp, 2014
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+xmlutils_PYTHON = *.py
+
+xmlutilsdir = $(pythondir)/kimchi/xmlutils
+
+install-data-local:
+	$(MKDIR_P) $(DESTDIR)$(xmlutilsdir)


### PR DESCRIPTION
After following README.md and running ‘sudo make install’ and then executing ‘kimchid –host=0.0.0.0’. The result is a stack trace:
# kimchid --host=0.0.0.0

Traceback (most recent call last):
  File "/usr/local/bin/kimchid", line 28, in <module>
    import kimchi.server
  File "/usr/local/lib/python2.7/site-packages/kimchi/server.py", line 26, in <module>
    from kimchi import auth
  File "/usr/local/lib/python2.7/site-packages/kimchi/auth.py", line 33, in <module>
    from kimchi import template
  File "/usr/local/lib/python2.7/site-packages/kimchi/template.py", line 25, in <module>
    from kimchi.config import paths
  File "/usr/local/lib/python2.7/site-packages/kimchi/config.py", line 30, in <module>
    from kimchi.xmlutils.utils import xpath_get_text
ImportError: No module named xmlutils.utils

xmlutils folder is not present in /usr/local/lib/python2.7/site-packages/kimchi/ :
# ls /usr/local/lib/python2.7/site-packages/kimchi/

API.json             config.pyc           featuretests.pyo     isoinfo.pyc          network.pyo          rollbackcontext.py   server.pyo           vmdisks.pyc
asynctask.py         config.pyo           i18n.py              isoinfo.pyo          objectstore.py       rollbackcontext.pyc  sslcert.py           vmdisks.pyo
asynctask.pyc        control/             i18n.pyc             kvmusertests.py      objectstore.pyc      rollbackcontext.pyo  sslcert.pyc          vmtemplate.py
asynctask.pyo        disks.py             i18n.pyo             kvmusertests.pyc     objectstore.pyo      root.py              sslcert.pyo          vmtemplate.pyc
auth.py              disks.pyc            imageinfo.py         kvmusertests.pyo     osinfo.py            root.pyc             swupdate.py          vmtemplate.pyo
auth.pyc             disks.pyo            imageinfo.pyc        mockmodel.py         osinfo.pyc           root.pyo             swupdate.pyc         vnc.py
auth.pyo             distroloader.py      imageinfo.pyo        mockmodel.pyc        osinfo.pyo           scan.py              swupdate.pyo         vnc.pyc
basemodel.py         distroloader.pyc     **init**.py          mockmodel.pyo        plugins/             scan.pyc             template.py          vnc.pyo
basemodel.pyc        distroloader.pyo     **init**.pyc         model/               proxy.py             scan.pyo             template.pyc
basemodel.pyo        exception.py         **init**.pyo         netinfo.py           proxy.pyc            screenshot.py        template.pyo
cachebust.py         exception.pyc        iscsi.py             netinfo.pyc          proxy.pyo            screenshot.pyc       utils.py
cachebust.pyc        exception.pyo        iscsi.pyc            netinfo.pyo          repositories.py      screenshot.pyo       utils.pyc
cachebust.pyo        featuretests.py      iscsi.pyo            network.py           repositories.pyc     server.py            utils.pyo
config.py            featuretests.pyc     isoinfo.py           network.pyc          repositories.pyo     server.pyc           vmdisks.py

Copying xmlutils folder from kimchi/src/kimchi/xmlutils to /usr/local/lib/python2.7/site-packages/kimchi/xmlutils fixes the issue so it appeared to be a ‘make install’ issue.

Patch:

diff --git a/configure.ac b/configure.ac
index d64ddc2..6a06a93 100644
--- a/configure.ac
+++ b/configure.ac
@@ -83,6 +83,7 @@ AC_CONFIG_FILES([
     src/kimchi/Makefile
     src/kimchi/control/Makefile
     src/kimchi/control/vm/Makefile
-    src/kimchi/xmlutils/Makefile
   src/kimchi/model/Makefile
   plugins/Makefile
   plugins/sample/Makefile
  diff --git a/src/kimchi/Makefile.am b/src/kimchi/Makefile.am
  index 84def58..5c204e0 100644
  --- a/src/kimchi/Makefile.am
  +++ b/src/kimchi/Makefile.am
  @@ -17,7 +17,7 @@
  # License along with this library; if not, write to the Free Software
  # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA

-SUBDIRS = control model
+SUBDIRS = control model xmlutils

 kimchi_PYTHON = $(filter-out config.py, $(wildcard *.py))

diff --git a/src/kimchi/xmlutils/Makefile.am b/src/kimchi/xmlutils/Makefile.am
new file mode 100644
index 0000000..4f662c9
--- /dev/null
+++ b/src/kimchi/xmlutils/Makefile.am
@@ -0,0 +1,25 @@
+#
+# Kimchi
+#
+# Copyright Intel Corp, 2014
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+xmlutils_PYTHON = *.py
+
+xmlutilsdir = $(pythondir)/kimchi/xmlutils
+
+install-data-local:
-       $(MKDIR_P) $(DESTDIR)$(xmlutilsdir)
