### PR TITLE
Expressly set autoport to yes in vm graphics.

### DIFF
--- a/src/kimchi/xmlutils/graphics.py
+++ b/src/kimchi/xmlutils/graphics.py
@@ -32,7 +32,7 @@ def get_graphics_xml(params):
       <target type='virtio' name='com.redhat.spice.0'/>
     </channel>
     """
-    graphics = E.graphics(type=params['type'], listen=params['listen'])
+    graphics = E.graphics(type=params['type'], autoport='yes', listen=params['listen'])
     graphics_xml = ET.tostring(graphics, encoding='utf-8', pretty_print=True)
 
     if params['type'] == 'vnc':


### PR DESCRIPTION
I had some problems when trying to get spice working on Arch Linux. Turned out that autoport was defaulting to no. This changes Kimchi to expressly set it to yes to prevent this happening to anyone else.
