### PR TITLE
Fix a ZeroDivisionError when starting kimchi service in Qemu.

### DIFF
--- a/src/kimchi/model/cpuinfo.py
+++ b/src/kimchi/model/cpuinfo.py
@@ -84,6 +84,8 @@ class CPUInfoModel(object):
             if not rc:
                 self.threads_per_core = int(out.split()[-1])
             self.sockets = self.cores_present/self.threads_per_core
+            if self.sockets == 0:
+                self.sockets = 1
             self.cores_per_socket = self.cores_present/self.sockets
         else:
             # Intel or AMD


### PR DESCRIPTION
 When using Kimchi inside a virtual machine it's possible to get a
 ZeroDivisionError exception because self.sockets is 0, so the
 division self.cores_per_socket = self.cores_present/self.sockets will
 fail. In this particular case, self.sockets is 0 because threads_per_core
 is higher than cores_present which will truncate the value to 0 during
 the integer division.

 This is a low priority corner case because Kimchi is obviously not
 supposed to run under a virtual machine but for a plugin development,
 which will not use any virtualization capability, it might become
 handy.