### PR TITLE
Fix service installation on non-systemd environments

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -115,11 +115,11 @@ ChangeLog:
 	fi
 
 install-data-local:
-	@if  test -d $(systemdsystemunitdir) ; then \
+	@if  test -d "$(systemdsystemunitdir)" ; then \
 		mkdir -p $(DESTDIR)/$(systemdsystemunitdir); \
 		$(INSTALL_DATA) contrib/kimchid.service.fedora $(DESTDIR)/$(systemdsystemunitdir)/kimchid.service; \
 	else \
-		mkdir -p $(DESTDIR)/etc/init.d/ \
+		mkdir -p $(DESTDIR)/etc/init.d/; \
 		$(INSTALL_DATA) contrib/kimchid.sysvinit $(DESTDIR)/etc/init.d/kimchid; \
 		chmod +x $(DESTDIR)/etc/init.d/kimchid; \
     fi; \


### PR DESCRIPTION
On RHEL 6-based environments, the instruction « test -d $(systemdsystemunitdir) » seems to be always true, even if $(systemdsystemunitdir) is undefined. Using quotes fixes this bad behaviour.
A missing semicolon prevents also the Sysv service file to be installed.