### PR TITLE
Identify CentOS 7 ISO

### DIFF
--- a/isoinfo.py
+++ b/isoinfo.py
@@ -47,6 +47,8 @@ iso_dir = [
         ('OpenBSD/(i386|amd64)    (\d+\.\d+) Install CD')),
     ('centos', lambda m: m.group(1),
         ('CentOS_(\d+\.\d+)_Final')),
+    ('centos', lambda m: m.group(1),
+        ('CentOS (\d+) ')),
     ('windows', '2000',
         ('W2AFPP|SP1AFPP|SP2AFPP|YRMAFPP|ZRMAFPP|W2AOEM|SP1AOEM|SP2AOEM' +
          '|YRMAOEM|ZRMAOEM|W2ASEL|SP2ASEL|W2SFPP|SP1SFPP|SP2SFPP|YRMSFPP' +


### PR DESCRIPTION
CentOS 7 x86_64 minimal ISO is labeld "CentOS 7 x86_64", so operating system is not recognized by Kimchi. This patch will fix this.