### PR TITLE
Add python-pil as a dependency requirement for Kimchi.

### DIFF
--- a/docs/ubuntu-deps.md
+++ b/docs/ubuntu-deps.md
@@ -20,7 +20,7 @@ Runtime Dependencies
                             python-ethtool sosreport python-ipaddr \
                             python-lxml open-iscsi python-guestfs \
                             libguestfs-tools spice-html5 python-magic \
-                            python-paramiko
+                            python-paramiko python-pil
 
 Packages required for UI development
 ------------------------------------


### PR DESCRIPTION
Added package python-pil to runtime dependencies for Kimchi as this package was not installed by default on my system (running Ubuntu 15.10).
