### PR TITLE
Make vnc to windows mouse sync

### DIFF
--- a/osinfo.py
+++ b/osinfo.py
@@ -74,7 +74,10 @@ template_specs = {'x86': {'old': dict(disk_bus='ide',
                                              tablet_bus='usb')}}
 
 
-custom_specs = {'fedora': {'22': dict(video_model='qxl')}}
+custom_specs = {'fedora': {'22': dict(video_model='qxl')},
+                'windows': {'0': dict(kbd_bus='usb',
+                                      kbd_type="keyboard",
+                                      tablet_bus='usb')}}
 
 
 modern_version_bases = {'x86': {'debian': '6.0', 'ubuntu': '7.10',


### PR DESCRIPTION
Add `<input type='tablet' bus='usb'/>` to windows guest define.

For detail see https://github.com/kanaka/noVNC/issues/131 and https://bugs.launchpad.net/nova/+bug/885966
