### PR TITLE
Add Fedora 25 images to fedora.json

### DIFF
--- a/distros.d/fedora.json
+++ b/distros.d/fedora.json
@@ -21,6 +21,12 @@
         "path": "http://mirrors.kernel.org/fedora/releases/24/Workstation/x86_64/iso/Fedora-Workstation-Live-x86_64-24-1.2.iso"
     },
     {
+        "name": "Fedora 25",
+        "os_distro": "fedora",
+        "os_arch": "25",
+        "path": "https://mirrors.kernel.org/fedora/releases/25/Workstation/x86_64/iso/Fedora-Workstation-Live-x86_64-25-1.3.iso"
+    },
+    {
         "name": "Fedora 22",
         "os_distro": "fedora",
         "os_arch": "ppc64",
@@ -61,5 +67,19 @@
         "os_arch": "ppc64le",
         "os_version": "24",
         "path": "http://mirrors.kernel.org/fedora-secondary/releases/24/Server/ppc64le/iso/Fedora-Server-netinst-ppc64le-24-1.2.iso"
+    },
+    {
+        "name": "Fedora 25",
+        "os_distro": "fedora",
+        "os_arch": "ppc64",
+        "os_version": "25",
+        "path": "https://mirrors.kernel.org/fedora-secondary/releases/25/Server/ppc64/iso/Fedora-Server-netinst-ppc64-25-1.2.iso"
+    },
+    {
+        "name": "Fedora 25 LE",
+        "os_distro": "fedora",
+        "os_arch": "ppc64le",
+        "os_version": "25",
+        "path": "https://mirrors.kernel.org/fedora-secondary/releases/25/Server/ppc64le/iso/Fedora-Server-netinst-ppc64le-25-1.2.iso"
     }
 ]


### PR DESCRIPTION
Workstation-Live-x86_64, Server-netinst-ppc64, Server-netinst-ppc64le.

This file looks a bit heterogeneous to me.
Using https instead of http because mirrors.kernel.org is available on https only (http://mirrors.kernel.org redirects to https://mirrors.kernel.org).