### PR TITLE
Add pkg-config to build deps

### DIFF
--- a/docs/ubuntu-deps.md
+++ b/docs/ubuntu-deps.md
@@ -10,7 +10,7 @@ Build Dependencies
 --------------------
 
     $ sudo apt-get install gcc make autoconf automake gettext git pkgconf \
-                           xsltproc
+                           xsltproc pkg-config
 
 Runtime Dependencies
 --------------------


### PR DESCRIPTION
Add pkg-config to build deps as it is needed to generate the contrib/DEBIAN/control file used by the contrib/make-deb.sh script. See https://github.com/kimchi-project/wok/issues/214, where building a .deb fails as it can't find the DEBIAN/control file.