### PR TITLE
Fix VNC 1006: urlencode path

### DIFF
--- a/ui/js/src/kimchi.api.js
+++ b/ui/js/src/kimchi.api.js
@@ -320,13 +320,15 @@ var kimchi = {
                 type : "POST",
                 dataType : "json"
             }).done(function() {
+                var path = server_root + "/websockify";
+                path += "?token=" + wok.urlSafeB64Encode(vm+'-console').replace(/=*$/g, "");
+                path += '&encrypt=1';
+
                 url = 'https://' + location.hostname + ':' + proxy_port;
                 url += server_root;
                 url += "/plugins/kimchi/serial/html/serial.html";
                 url += "?port=" + proxy_port;
-                url += "&path=" + server_root + "/websockify";
-                url += "?token=" + wok.urlSafeB64Encode(vm+'-console').replace(/=*$/g, "");
-                url += '&encrypt=1';
+                url += "&path=" + encodeURIComponent(path);
                 window.open(url);
             }).error(function(data) {
                 wok.message.error(data.responseJSON.reason);
@@ -344,11 +346,7 @@ var kimchi = {
             type : "POST",
             dataType : "json"
         }).done(function() {
-            url = 'https://' + location.hostname + ':' + proxy_port;
-            url += server_root;
-            url += "/plugins/kimchi/novnc/vnc_auto.html";
-            url += "?port=" + proxy_port;
-            url += "&path=" + server_root + "/websockify";
+            var path = server_root + "/websockify";
             /*
              * From python documentation base64.urlsafe_b64encode(s)
              * substitutes - instead of + and _ instead of / in the
@@ -356,8 +354,14 @@ var kimchi = {
              * contain = which is not safe in a URL query component.
              * So remove it when needed as base64 can work well without it.
              * */
-            url += "?token=" + wok.urlSafeB64Encode(vm).replace(/=*$/g, "");
-            url += '&encrypt=1';
+            path += "?token=" + wok.urlSafeB64Encode(vm).replace(/=*$/g, "");
+            path += '&encrypt=1';
+
+            url = 'https://' + location.hostname + ':' + proxy_port;
+            url += server_root;
+            url += "/plugins/kimchi/novnc/vnc_auto.html";
+            url += "?port=" + proxy_port;
+            url += "&path=" + encodeURIComponent(path);
             window.open(url);
         });
     },


### PR DESCRIPTION
Currently kimchi directs you to `https://hera.lan:8001/plugins/kimchi/novnc/vnc_auto.html?port=8001&path=/websockify?token=[...]&encrypt=1` when you click on 'View Console`, however this is improperly encoded and Firefox guesses that the second `?` was meant to be an `&`. This means that `token` and `encrypt` are sent to the current page rather than being used for the websocket path.

It seems that noVNC should "work" with this, but there's another bug (or kimchi is using path improperly, not sure, could be fixed in either AFAIK) in noVNC where it assumes path is relative and prepends a `/` to it, which then when it uses and anchor tag to reformat the URL (I think) in `WebUtil.injectParamIfMissing`. However when path already has a leading `/` it interprets "websockify" as the host (that is it becomes `//websockify/`) and the path becomes just `/?token=[...]`.

That code path is only executed when token is part of the original URL, so this commit urlencodes the path to prevent the interpretation of the token in the original URL and use it only in path. This could also be fixed by changing the `?` to an `&` and removing the leading `/`. However, `encodeURIcomponent` should probably be used regardless since parts of path can come from a config file.

**Caveats**

This is **UNTESTED** because I don't know how to build it all and don't feel like figuring out right now, but I have manually tested it with the URL I believe this should produce.

I wasn't totally sure about the encrypt param because it was just another & param in the URL and there's nothing to indicate where if it's part of path or part of the page url. However, it doesn't seem to make a visible difference where it's put, or even if it is removed. (This would also make a difference to the alternate solution I suggested above.)

