### PR TITLE
Add a configuration option for disabling taking a screenshot

### DIFF
--- a/kimchi.conf
+++ b/kimchi.conf
@@ -5,3 +5,6 @@ enable = True
 [kimchi]
 # Automatically create ISO pool on server start up
 create_iso_pool = True
+# Toggles whether to take a screenshot for the web-interface
+# Warning: Screenshots include a massive performance penalty
+take_screenshot = True

--- a/model/vms.py
+++ b/model/vms.py
@@ -1291,8 +1291,10 @@ class VMModel(object):
         graphics = self.get_graphics(name, self.conn)
         graphics_port = graphics[2]
         graphics_port = graphics_port if state == 'running' else None
+        # only take a screenshot if configured to do so
+        take_screenshot = config.get('kimchi', {}).get('take_screenshot', True)
         try:
-            if state == 'running' and self._has_video(dom):
+            if take_screenshot and state == 'running' and self._has_video(dom):
                 screenshot = self.vmscreenshot.lookup(name)
             elif state == 'shutoff':
                 # reset vm stats when it is powered off to avoid sending


### PR DESCRIPTION
On my system with 23 running VMs, this takes 1.5 minutes to load /plugins/kimchi/vm beforehand, and 2 seconds when disabled.

Resolves #1130