### PR TITLE
Resolve Issue #1256: List of guests should always show the link to access guest via VNC or Spice

### DIFF
--- a/ui/css/kimchi.css
+++ b/ui/css/kimchi.css
@@ -960,12 +960,6 @@
   }
 }
 
-/*
-#guest-content-container .wok-guest-list .wok-guest-list-header > span.column-vnc,
-#guest-content-container .wok-guest-list .wok-guest-list-body .wok-guest-list-item > span.column-vnc {
-  display: none;
-}*/ 
-
 #guest-content-container .wok-guest-list .wok-guest-list-header > span.column-vnc > a,
 #guest-content-container .wok-guest-list .wok-guest-list-body .wok-guest-list-item > span.column-vnc > a {
   font-weight: normal;

--- a/ui/css/kimchi.css
+++ b/ui/css/kimchi.css
@@ -960,10 +960,11 @@
   }
 }
 
+/*
 #guest-content-container .wok-guest-list .wok-guest-list-header > span.column-vnc,
 #guest-content-container .wok-guest-list .wok-guest-list-body .wok-guest-list-item > span.column-vnc {
   display: none;
-}
+}*/ 
 
 #guest-content-container .wok-guest-list .wok-guest-list-header > span.column-vnc > a,
 #guest-content-container .wok-guest-list .wok-guest-list-body .wok-guest-list-item > span.column-vnc > a {

--- a/ui/pages/tabs/guests.html.tmpl
+++ b/ui/pages/tabs/guests.html.tmpl
@@ -51,7 +51,7 @@
                       <span class="column-state"><span class="sr-only">$_("State")</span></span><!--
                       --><span class="column-name"><span title="$_('Guest Name ID')">$_("Guest Name ID")</span></span><!--
                       --><span class="column-type"><span title="$_('OS Type')">$_("OS Type")</span></span><!--
-                      --><span class="column-vnc"><span title="$_('VNC')">$_("VNC")</span></span><!--
+                      --><span class="column-vnc"><span title="$_('VNC/Spice')">$_("VNC/Spice")</span></span><!--
                       --><span class="column-processors"><span title="$_('Processors Utilization')">$_("Processors Utilization")</span></span><!--
                       --><span class="column-memory"><span title="$_('Memory Utilization')">$_("Memory Utilization")</span></span><!--
                       --><span class="column-storage"><span title="$_('Storage I/O')">$_("Storage I/O")</span></span><!--


### PR DESCRIPTION
List of guests should always show the link to access guest via VNC or Spice

This Resolve addresses an issue VNC column disappear when there is not enough space (id screen is too small, that column is hidden. workaround: do CTRL - in the browser) , yet it is one of the most important columns.
Rename from "VNC" to "VNC/Spice" because if the connection is via Spice, it still goes in this column.
Resolves #1256