### PR TITLE
Issue 1242: Allow either python-imaging or python-pil in installer

### DIFF
--- a/contrib/DEBIAN/control.in
+++ b/contrib/DEBIAN/control.in
@@ -4,7 +4,7 @@ Section: base
 Priority: optional
 Architecture: all
 Depends: wok (>= 2.1.0),
-         python-imaging,
+         python-imaging | python-pil,
          python-configobj,
          novnc,
          python-jsonschema (>= 1.3.0),


### PR DESCRIPTION
Adjusted the `control.in` file to allow either `python-imaging` or `python-pil` when installing from a .deb. This will allow users running Ubuntu 18.04 to install from built packages.