### PR TITLE
Issue #1264 : Libvirt check should only look for socket

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -116,6 +116,7 @@ do_substitution = \
 	-e 's,[@]datadir[@],$(datadir),g'               \
 	-e 's,[@]sysconfdir[@],$(sysconfdir),g'         \
 	-e 's,[@]localstatedir[@],$(localstatedir),g'   \
+	-e 's,[@]runstatedir[@],$(runstatedir),g'       \
 	-e 's,[@]pkgdatadir[@],$(pkgdatadir),g'         \
 	-e 's,[@]wokdir[@],$(wokdir),g'           			\
 	-e 's,[@]kimchidir[@],$(kimchidir),g'           \

--- a/config.py.in
+++ b/config.py.in
@@ -37,6 +37,8 @@ __release__ = "@kimchirelease@"
 # Storage pool constant for read-only pool types
 READONLY_POOL_TYPE = ['iscsi', 'scsi', 'mpath']
 
+def get_libvirt_path():
+    return os.path.join("@runstatedir@", 'libvirt')
 
 def get_kimchi_version():
     return "-".join([__version__, __release__])

--- a/utils.py
+++ b/utils.py
@@ -22,6 +22,7 @@ import json
 import os
 import re
 import sqlite3
+import stat
 import time
 import urllib
 from http.client import HTTPConnection
@@ -262,11 +263,17 @@ def get_next_clone_name(all_names, basename, name_suffix='', ts=False):
 
 def is_libvirtd_up():
     """
-    Checks if libvirtd.service is up.
+    Checks if libvirt is up.
     """
-    cmd = ['systemctl', 'is-active', 'libvirtd.service']
-    output, error, rc = run_command(cmd, silent=True)
-    return True if output == 'active\n' else False
+    path = os.path.join(config.get_libvirt_path(), 'libvirt-sock')
+    try:
+        mode = os.stat(path).st_mode
+        if stat.S_ISSOCK(mode):
+            return True
+    except:
+        pass
+
+    return False
 
 
 def is_s390x():


### PR DESCRIPTION
Change  is_libvirtd_up function to check libvirt socket instead of systemd

# Pull Request Template

## Description

Please, include a summary of the patch and why it should be accepted.
Link it to any open issue and share any other information and context you judge relevant for this PR.

Fixes # (issue)

## How Has This Been Tested?

Please, describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have signed-off my commit (git commit -s) to certify I have the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see http://developercertificate.org/ for more information).
- [x] My code follows the style guidelines of this project and I have run `make check-local` to confirm it.
- [x] I have run `make` to build the project and update any documentation that was added as part of this PR.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (Run `make check` to confirm it)
