### PR TITLE
Issue #1224 : kvmusertest.py: hardcoded path prevents kimchi module f…

### DIFF
--- a/kvmusertests.py
+++ b/kvmusertests.py
@@ -20,6 +20,7 @@ import threading
 
 import libvirt
 import psutil
+from wok.plugins.kimchi.config import get_libvirt_path
 from wok.rollbackcontext import RollbackContext
 
 KVMUSERTEST_VM_NAME = 'KVMUSERTEST_VM'
@@ -60,7 +61,7 @@ class UserTests(object):
                 f = libvirt.VIR_DOMAIN_START_AUTODESTROY
                 dom = conn.createXML(xml, flags=f)
                 rollback.prependDefer(dom.destroy)
-                filename = '/var/run/libvirt/qemu/%s.pid' % KVMUSERTEST_VM_NAME
+                filename = get_libvirt_path() + '/qemu/%s.pid' % KVMUSERTEST_VM_NAME
                 with open(filename) as f:
                     pidStr = f.read()
                 p = psutil.Process(int(pidStr))


### PR DESCRIPTION
…rom loading when /usr/local prefixes /var

# Pull Request Template

## Description

Please, include a summary of the patch and why it should be accepted.
Link it to any open issue and share any other information and context you judge relevant for this PR.

Fixes # (issue)

## How Has This Been Tested?

Please, describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [ ] I have signed-off my commit (git commit -s) to certify I have the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see http://developercertificate.org/ for more information).
- [ ] My code follows the style guidelines of this project and I have run `make check-local` to confirm it.
- [ ] I have run `make` to build the project and update any documentation that was added as part of this PR.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (Run `make check` to confirm it)
