### PR TITLE
Updated README.md for missing dependency

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -148,6 +148,14 @@ There will be a message like:
 
     Failed to import plugin wok.plugins.kimchi.Kimchi, error: XXX
 
+If the log shows details of a missing dependency, like this:
+
+    Failed to import plugin wok.plugins.kimchi.Kimchi, error: No module named 'ipaddr'
+
+You have to install this dependency manually due to changes in upstream. For that change ${RELEASE_NUMBER} to your version of the release:
+
+    sudo -H pip3 install https://github.com/kimchi-project/kimchi/raw/${RELEASE_NUMBER}/requirements-FEDORA.txt
+
 #### NFS storage pool
 Please, check the NFS export path permission is configured like below:
 


### PR DESCRIPTION
Added annotation for new user to easily install kimchi without a problem where the ipaddr pip module doesn't get installed automatically as it's apparently not required any more in newer releases.
